### PR TITLE
$this->params() has been replaced in Cake 2.*  CakeRequest is now used to access same

### DIFF
--- a/Controller/Component/WizardComponent.php
+++ b/Controller/Component/WizardComponent.php
@@ -357,7 +357,7 @@ class WizardComponent extends Component {
 		if ($step == null) {
 			$step = $this->_getExpectedStep();
 		}
-		$url = array('controller' => $this->controller->params['controller'], 'action' => $this->action, $step);
+		$url = array('controller' => $this->controller->request->controller, 'action' => $this->action, $step);
 		$this->controller->redirect($url, $status, $exit);
 	}
 /**


### PR DESCRIPTION
Instead of $this->controller->params['controller'], any of the following should be used:

$this->controller->request['controller'];
$this->controller->request->controller;
$this->controller->request->params['controller'];

http://book.cakephp.org/2.0/en/controllers/request-response.html#accessing-request-parameters.
